### PR TITLE
refactor(lockscreen): Refactor UserLogin and enhance macOS aesthetic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,14 @@ function App() {
   const handleKeyPress = useCallback(
     (event: any) => {
       if (event.key === 'F10') {
-        handle.enter();
+        try {
+          const promise = handle.enter();
+          if (promise && promise.catch) {
+            promise.catch((err: any) => console.warn('Fullscreen error:', err));
+          }
+        } catch (err) {
+          console.warn('Fullscreen error:', err);
+        }
       } else if (event.key === 'Escape') {
         handle.exit();
       }
@@ -23,7 +30,14 @@ function App() {
   useEffect(() => {
     const enterFullScreen = () => {
       if (!handle.active) {
-        handle.enter();
+        try {
+          const promise = handle.enter();
+          if (promise && promise.catch) {
+            promise.catch((err: any) => console.warn('Fullscreen error:', err));
+          }
+        } catch (err) {
+          console.warn('Fullscreen error:', err);
+        }
       }
     };
 

--- a/src/localization/locales/en/main.json
+++ b/src/localization/locales/en/main.json
@@ -20,6 +20,8 @@
     "loginPasswordText1": "Touch ID or Enter password",
     "loginPasswordText2": "Your password is required to enable Touch ID",
     "inputPlaceholder": "Enter Password",
+    "passwordHintLabel": "Password Hint",
+    "passwordHint": "Your password is the same as your macOS user account password. If you've forgotten it, try entering your Apple ID password or use the Reset Password assistant. Please use - 'Amit'",
     "keyboard": {
       "type": "ABC - India",
       "option": {

--- a/src/screens/public/Lock/component/TimeDate.tsx
+++ b/src/screens/public/Lock/component/TimeDate.tsx
@@ -23,7 +23,14 @@ const MemoisedTimeComponent = React.memo(TimeComponent);
 const MemoisedDateComponent = React.memo(DateComponent);
 
 const TimeDateComponent = () => {
-  const { date, time } = uiStore(useShallow(dateTimeSelector));
+  const { dateObject } = uiStore(useShallow(dateTimeSelector));
+
+  const formattedDate = dateObject?.toDateString().slice(0, 10) ?? '';
+  const formattedTime = dateObject?.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }) ?? '';
 
   return (
     <Box
@@ -36,8 +43,8 @@ const TimeDateComponent = () => {
       zIndex={0}
       aria-label="time-date-component"
     >
-      <MemoisedDateComponent date={date?.slice(0, 10) ?? ''} />
-      <MemoisedTimeComponent time={time?.slice(0, 5) ?? ''} />
+      <MemoisedDateComponent date={formattedDate} />
+      <MemoisedTimeComponent time={formattedTime} />
     </Box>
   );
 };

--- a/src/screens/public/Lock/component/UserLogin.tsx
+++ b/src/screens/public/Lock/component/UserLogin.tsx
@@ -1,12 +1,16 @@
 import { ArrowRightCircleIcon } from '@assets';
 import {
   Box,
-  Button,
-  IconButton,
   Image,
   Input,
   InputGroup,
   InputRightElement,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
   Spinner,
   Text,
   useBoolean,
@@ -16,137 +20,319 @@ import { settingsStore, usersSelector } from '@settingsStore';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+interface UserAvatarButtonProps {
+  src: string;
+  name: string;
+  isOpen: boolean;
+  onClick: () => void;
+}
+
+const UserAvatarButton = ({
+  src,
+  name,
+  isOpen,
+  onClick,
+}: UserAvatarButtonProps) => (
+  <Box
+    aria-label="user-button"
+    role="button"
+    tabIndex={0}
+    position="fixed"
+    bottom="24%"
+    display="flex"
+    flexDirection="column"
+    alignItems="center"
+    gap={2}
+    cursor="pointer"
+    onClick={onClick}
+    onKeyDown={(e) => e.key === 'Enter' && onClick()}
+    sx={{
+      '&:hover .avatar-ring': {
+        boxShadow: '0 0 0 3px rgba(255,255,255,0.85)',
+        transform: 'scale(1.06)',
+      },
+      '&:hover .avatar-name': {
+        opacity: 1,
+      },
+    }}
+  >
+    {/* Circular avatar with ring glow on hover */}
+    <Box
+      className="avatar-ring"
+      borderRadius="full"
+      overflow="hidden"
+      boxSize="56px"
+      boxShadow="0 0 0 2px rgba(255,255,255,0.3)"
+      transition="transform 0.25s ease, box-shadow 0.25s ease"
+      flexShrink={0}
+    >
+      <Image
+        src={src}
+        alt="Profile"
+        boxSize="56px"
+        objectFit="cover"
+      />
+    </Box>
+
+    {/* Username — always rendered, fades in on expanded */}
+    <Text
+      className="avatar-name"
+      color="white"
+      fontSize={15}
+      fontWeight={500}
+      whiteSpace="nowrap"
+      opacity={isOpen ? 1 : 0.75}
+      transition="opacity 0.25s ease"
+      letterSpacing="0.01em"
+      textShadow="0 1px 4px rgba(0,0,0,0.6)"
+    >
+      {name}
+    </Text>
+  </Box>
+);
+
+interface PasswordInputProps {
+  value: string;
+  placeholder: string;
+  isLoading: boolean;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+}
+
+const PasswordInput = ({
+  value,
+  placeholder,
+  isLoading,
+  onChange,
+  onSubmit,
+}: PasswordInputProps) => (
+  <InputGroup width="48" height="10" gap={1}>
+    <Input
+      aria-label="password-text-input"
+      placeholder={placeholder}
+      variant="solid"
+      type="password"
+      fontSize={14}
+      height="26px"
+      borderRadius="20"
+      value={value}
+      margin={0}
+      alignSelf="center"
+      width="sm"
+      maxLength={20}
+      bgColor="#0000007f"
+      color="#fff"
+      onChange={(e) => onChange(e.target.value)}
+      onKeyPress={(e) => {
+        if (e.key === 'Enter') onSubmit();
+      }}
+    />
+    <InputRightElement marginRight={1} height="100%" alignItems="center">
+      {isLoading ? (
+        <Spinner size="sm" aria-label="spinner" color="whiteAlpha.700" />
+      ) : (
+        <Box
+          as="button"
+          aria-label="login-button"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          cursor="pointer"
+          color="whiteAlpha.700"
+          fontSize="18px"
+          transition="color 0.2s ease, transform 0.2s ease"
+          _hover={{
+            color: 'white',
+            transform: 'translateX(2px)',
+            filter: 'drop-shadow(0 0 4px rgba(255,255,255,0.6))',
+          }}
+          _active={{ transform: 'translateX(1px) scale(0.9)' }}
+          onClick={onSubmit}
+          background="none"
+          border="none"
+          padding={0}
+        >
+          <ArrowRightCircleIcon width="18px" height="18px" />
+        </Box>
+      )}
+    </InputRightElement>
+  </InputGroup>
+);
+
+// ─── HintPopover ─────────────────────────────────────────────────────────────
+
+interface HintPopoverProps {
+  label: string;
+  hint: string;
+}
+
+const HintPopover = ({ label, hint }: HintPopoverProps) => (
+  <Popover placement="top" isLazy>
+    <PopoverTrigger>
+      <Box
+        as="button"
+        aria-label="password-hint-button"
+        display="inline-flex"
+        alignItems="center"
+        justifyContent="center"
+        boxSize="18px"
+        borderRadius="full"
+        border="1.5px solid rgba(255,255,255,0.45)"
+        color="rgba(255,255,255,0.55)"
+        fontSize="11px"
+        fontWeight={600}
+        cursor="pointer"
+        background="none"
+        transition="border-color 0.2s ease, color 0.2s ease"
+        _hover={{
+          borderColor: 'rgba(255,255,255,0.9)',
+          color: 'white',
+        }}
+      >
+        ?
+      </Box>
+    </PopoverTrigger>
+    <PopoverContent
+      bg="rgba(30,30,30,0.4)"
+      backdropFilter="blur(24px)"
+      border="1px solid rgba(255,255,255,0.15)"
+      boxShadow="0 8px 32px rgba(0,0,0,0.5)"
+      borderRadius={12}
+      color="white"
+      maxW="260px"
+      fontSize={13}
+    >
+      <PopoverArrow bg="rgba(30,30,30,0.4)" />
+      <PopoverHeader
+        fontSize={12}
+        fontWeight={600}
+        color="rgba(255,255,255,0.55)"
+        borderColor="rgba(255,255,255,0.1)"
+        letterSpacing="0.04em"
+        textTransform="uppercase"
+        pb={1}
+      >
+        {label}
+      </PopoverHeader>
+      <PopoverBody lineHeight={1.6} color="rgba(255,255,255,0.85)">
+        {hint}
+      </PopoverBody>
+    </PopoverContent>
+  </Popover>
+);
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const LOGIN_DELAY_MS = 2000;
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
 const UserLoginComponent = () => {
   const { t } = useTranslation();
-  const [password, setPassword] = useState<string>('');
-  const { login, isUserLocked } = processStore(useShallow(loginSelector));
-  const [passwordFieldVisibility, togglePasswordFieldVisibility] = useBoolean();
-  const [isLoading, toggleIsLoading] = useBoolean();
-  const {
-    name,
-    password: userPasswordData,
-    profilePicture,
-  } = settingsStore(useShallow(usersSelector)).userData;
 
-  const onUserLoginHandler = useCallback(() => {
+  const [password, setPassword] = useState<string>('');
+  const [isPasswordVisible, togglePasswordVisibility] = useBoolean();
+  const [isLoading, toggleIsLoading] = useBoolean();
+
+  const { login, isUserLocked } = processStore(useShallow(loginSelector));
+  const { name, password: userPasswordData, profilePicture } =
+    settingsStore(useShallow(usersSelector)).userData;
+
+  const handleLogin = useCallback(() => {
+    if (isLoading) return;
+
     toggleIsLoading.on();
-    // Add validate logic
-    !isLoading &&
-      setTimeout(() => {
-        if (password === userPasswordData) {
-          login();
-        }
-        toggleIsLoading.off();
-      }, 2000);
+    console.log('[UserLogin] Login attempt started');
+
+    setTimeout(() => {
+      if (password === userPasswordData) {
+        console.log('[UserLogin] Password matched — logging in');
+        login();
+      } else {
+        console.warn('[UserLogin] Incorrect password');
+      }
+      toggleIsLoading.off();
+    }, LOGIN_DELAY_MS);
   }, [isLoading, login, password, toggleIsLoading, userPasswordData]);
 
-  return (
-    <Box
-      width={'100%'}
-      alignItems={'center'}
-      position={'fixed'}
-      bottom={'15%'}
-      display={'flex'}
-      flexDirection={'column'}
-      zIndex={0}
-      aria-label="user-login-component"
-      gap={2}
-    >
-      <Button
-        aria-label="user-button"
-        padding={1}
-        variant={'ghost'}
-        colorScheme="gray"
-        size={'48px'}
-        width={'64'}
-        position={'fixed'}
-        bottom={'24%'}
-        borderRadius={14}
-        _hover={{
-          transform: 'scale(1.05)',
-          shadow: '1px',
-          background: '#0f0f0f67',
-        }}
-        transition={'all 0.5s'}
-        onClick={() => {
-          togglePasswordFieldVisibility.toggle();
-        }}
-        gap={6}
-      >
-        <Image
-          borderRadius="full"
-          src={profilePicture}
-          alt="Profile"
-          width="48px"
-          transition={'all 1s'}
-        />
-        <Text
-          display={passwordFieldVisibility ? 'flex' : 'none'}
-          color={'white'}
-          fontSize={14}
-          fontWeight={600}
-          transition={'all 1s'}
-        >
-          {name}
-        </Text>
-      </Button>
+  const statusTextKey = isUserLocked
+    ? 'LockScreen.loginPasswordText1'
+    : 'LockScreen.loginPasswordText2';
 
-      <InputGroup
-        display={passwordFieldVisibility ? 'flex' : 'none'}
-        transition={'all 0.5s'}
-        width={'48'}
-        height={'10'}
-        gap={1}
+  return (
+    <>
+      {/* Full-screen click-away overlay — dismisses password section on outside click */}
+      <Box
+        position="fixed"
+        inset={0}
+        zIndex={-1}
+        cursor="default"
+        opacity={isPasswordVisible ? 1 : 0}
+        pointerEvents={isPasswordVisible ? 'auto' : 'none'}
+        transition="opacity 0.3s ease"
+        onClick={togglePasswordVisibility.off}
+        aria-hidden="true"
+      />
+
+      <Box
+        aria-label="user-login-component"
+        width="100%"
+        position="fixed"
+        bottom="15%"
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        zIndex={0}
+        gap={2}
       >
-        <Input
-          aria-label="password-text-input"
-          placeholder={t('LockScreen.inputPlaceholder')}
-          variant={'solid'}
-          type="password"
-          fontSize={14}
-          height={'26px'}
-          borderRadius={'20'}
-          value={password}
-          margin={0}
-          alignSelf={'center'}
-          width={'sm'}
-          onChange={(text) => setPassword(text.target.value)}
-          onKeyPress={(key) => {
-            if (key.key === 'Enter') onUserLoginHandler();
-          }}
-          maxLength={20}
-          bgColor={'#0000007f'}
-          color={'#fff'}
+        <UserAvatarButton
+          src={profilePicture}
+          name={name}
+          isOpen={isPasswordVisible}
+          onClick={togglePasswordVisibility.toggle}
         />
-        <InputRightElement marginRight={1}>
-          {isLoading ? (
-            <Spinner size={'sm'} aria-label="spinner" />
-          ) : (
-            <IconButton
-              height={'5'}
-              variant={'ghost'}
-              onClick={onUserLoginHandler}
-              icon={<ArrowRightCircleIcon />}
-              borderRadius={'full'}
-              aria-label="login-button"
+
+        <Box 
+          display={isPasswordVisible ? 'flex' : 'none'} 
+          transition="all 0.5s" 
+          alignItems="center"
+          position="relative"
+        >
+          <PasswordInput
+            value={password}
+            placeholder={t('LockScreen.inputPlaceholder')}
+            isLoading={isLoading}
+            onChange={setPassword}
+            onSubmit={handleLogin}
+          />
+          {/* Password hint trigger — positioned to the right of the input */}
+          <Box
+            position="absolute"
+            right="-28px"
+            opacity={isPasswordVisible ? 1 : 0}
+            pointerEvents={isPasswordVisible ? 'auto' : 'none'}
+            transition="opacity 0.4s ease"
+          >
+            <HintPopover
+              label={t('LockScreen.passwordHintLabel')}
+              hint={t('LockScreen.passwordHint')}
             />
-          )}
-        </InputRightElement>
-      </InputGroup>
-      <Text
-        opacity={passwordFieldVisibility ? 1 : 0}
-        align={'center'}
-        fontSize={12}
-        color={'white'}
-        transition={'all 1s'}
-      >
-        {t(
-          isUserLocked
-            ? 'LockScreen.loginPasswordText1'
-            : 'LockScreen.loginPasswordText2',
-        )}
-      </Text>
-    </Box>
+          </Box>
+        </Box>
+
+        <Text
+          align="center"
+          fontSize={12}
+          color="white"
+          opacity={isPasswordVisible ? 1 : 0}
+          transition="all 1s"
+        >
+          {t(statusTextKey)}
+        </Text>
+      </Box>
+    </>
   );
 };
 

--- a/src/store/uiStore/selector/DateTime/DateTime.selector.ts
+++ b/src/store/uiStore/selector/DateTime/DateTime.selector.ts
@@ -1,5 +1,4 @@
 import { UiStoreState } from '../../uiStore';
-import _ from 'lodash';
 
 const dateTimeSelector = (state: UiStoreState) => ({
   dateObject: state.DateTime.date,
@@ -7,15 +6,11 @@ const dateTimeSelector = (state: UiStoreState) => ({
   dateWithoutYear: state.DateTime.date?.toDateString().slice(0, -5),
   time: state.DateTime.date?.toLocaleTimeString(),
   timeInAmPm: () => {
-    const time = state.DateTime.date
-      ?.toLocaleTimeString()
-      .split(':')
-      .slice(0, 2)
-      .join(':');
-    const hour = _.toNumber(time?.split(':')[0]);
-    if (hour > 12) return `${hour - 12}:${time?.split(':')[1]} PM`;
-
-    return `${time} AM`;
+    return state.DateTime.date?.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    }) || '';
   },
   initTimer: state.DateTime.init,
 });


### PR DESCRIPTION
Issue:
- Unhandled 'Permissions check failed' runtime error crashes dev server on fullscreen load.
- Undesired AM/PM string visible in Lock screen clock.
- Lock screen login UI was cluttered, used rectangular buttons, and lacked macOS authentic details like hints and click-away dismissal.

Root-cause:
- Fullscreen API requires a user gesture; programmatic calls return rejected promises which crashed the React dev server overlay.
- `toLocaleTimeString` was defaulting to 12-hour format in some locales.
- Chakra UI `Button` base styles conflicted with custom hover transforms, breaking the visual macOS aesthetic for the user avatar.

Fix:
- Catch rejected promises from the fullscreen API.
- Explicitly enforce 24-hour format (`hour12: false`) for the lock screen clock.
- Replace Chakra UI `Button` components with plain `Box` elements to achieve pure CSS circular avatars, stacked text layouts, and ring-glow hover animations.

Changes:
- App.tsx: Handle fullscreen promise rejection to fix permission errors.
- TimeDate.tsx: Force 24-hour time format removing AM/PM.
- DateTime.selector.ts: Refactor timeInAmPm to use native Intl API instead of lodash.
- UserLogin.tsx:
  - Extract subcomponents (UserAvatarButton, PasswordInput, HintPopover).
  - Adopt macOS-style circular avatar with hover ring.
  - Add translucent hint popover next to password input.
  - Add background click-away overlay.
- locales: Add password hint translation keys.