### PR TITLE
chore(MAC-6): Downgrade action-gh-release to v3

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -96,7 +96,7 @@ jobs:
           cd ..
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v4
+        uses: softprops/action-gh-release@v3
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}


### PR DESCRIPTION
# Description of changes

This PR downgrades the `softprops/action-gh-release` version from `v4` to `v3` in the `build-web.yml` workflow.

## Requirement

- Downgrade `action-gh-release` to `v3` to resolve release deployment issues.

## Implementation

- Changed `uses: softprops/action-gh-release@v4` to `uses: softprops/action-gh-release@v3` in [.github/workflows/build-web.yml](file:///.github/workflows/build-web.yml).

Ticket: [MAC-6](https://ar1603.atlassian.net/browse/MAC-6)
Author: Amit Raikwar